### PR TITLE
Add sunset banner to old gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,30 @@
     <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+    <style>
+        .sunset-banner {
+            width: 100%;
+            background-color: #e34850;
+            padding: 5px 10px;
+            text-align: center;
+            margin-bottom: 10px;
+            border-radius: 4px;
+            color: #f5f5f5;
+        }
+
+        .sunset-banner a {
+            color: #f5f5f5;
+            text-decoration: underline;
+        }
+    </style>
 </head>
 <body>
     <div class="container">
+        <div class="sunset-banner">
+            <span>The glossary site has moved to a new location and we will be shutting this page down.</span>
+            <br/>
+            <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary 2.0</a> site for the latest updates.</span>
+        </div>
         <nav class="navbar navbar-default navbar-fixed-top">
             <div class="container">
                 <div class="row">

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 <body>
     <div class="container">
         <div class="sunset-banner">
-            <span>The glossary site has moved to a new location and we will shut down this page soon.</span>
+            <span>The glossary site has moved to a new location, and we will shut down this page soon.</span>
             <br/>
             <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary</a> site for the latest updates.</span>
         </div>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,9 @@
 <body>
     <div class="container">
         <div class="sunset-banner">
-            <span>The glossary site has moved to a new location and we will be shutting this page down.</span>
+            <span>The glossary site has moved to a new location and we will shut down this page soon.</span>
             <br/>
-            <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary 2.0</a> site for the latest updates.</span>
+            <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary</a> site for the latest updates.</span>
         </div>
         <nav class="navbar navbar-default navbar-fixed-top">
             <div class="container">

--- a/word-usage.html
+++ b/word-usage.html
@@ -45,7 +45,7 @@
 <body>
     <div class="container">
         <div class="sunset-banner">
-            <span>The glossary site has moved to a new location and we will shut down this page soon.</span>
+            <span>The glossary site has moved to a new location, and we will shut down this page soon.</span>
             <br/>
             <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary</a> site for the latest updates.</span>
         </div>

--- a/word-usage.html
+++ b/word-usage.html
@@ -25,9 +25,30 @@
     <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
+    <style>
+        .sunset-banner {
+            width: 100%;
+            background-color: #e34850;
+            padding: 5px 10px;
+            text-align: center;
+            margin-bottom: 10px;
+            border-radius: 4px;
+            color: #f5f5f5;
+        }
+
+        .sunset-banner a {
+            color: #f5f5f5;
+            text-decoration: underline;
+        }
+    </style>
 </head>
 <body>
     <div class="container">
+        <div class="sunset-banner">
+            <span>The glossary site has moved to a new location and we will be shutting this page down.</span>
+            <br/>
+            <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary 2.0</a> site for the latest updates.</span>
+        </div>
         <nav class="navbar navbar-default navbar-fixed-top">
             <div class="container">
                 <div class="row">

--- a/word-usage.html
+++ b/word-usage.html
@@ -45,9 +45,9 @@
 <body>
     <div class="container">
         <div class="sunset-banner">
-            <span>The glossary site has moved to a new location and we will be shutting this page down.</span>
+            <span>The glossary site has moved to a new location and we will shut down this page soon.</span>
             <br/>
-            <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary 2.0</a> site for the latest updates.</span>
+            <span>Check out our brand new <a href="https://glossary.magento.com">Magento Glossary</a> site for the latest updates.</span>
         </div>
         <nav class="navbar navbar-default navbar-fixed-top">
             <div class="container">


### PR DESCRIPTION
## Scope of this PR

This PR adds a banner on the old gh-pages site that links to the new URL for the project.

## Screenshot
<img width="1165" alt="Screen Shot 2019-06-05 at 11 50 33 AM" src="https://user-images.githubusercontent.com/4692281/58974728-b6948700-8788-11e9-9024-1c3d7e7d36fa.png">

## Validation steps

1. Serve the contents of this branch using an http server application, such as [http-server](https://www.npmjs.com/package/http-server).
    
    Example command using http-server that has been globally installed: `http-server ./`
2. Navigate to the home page (`/index.html`)
3. Verify the banner appears
4. Click on the link in the banner
5. Verify you are directed to the new Magento Glossary site (`glossary.magento.com`)
6. Navigate to the word-usage page (`/word-usage.html`)
7. Verify the banner appears
8. Click on the link in the banner
9. Verify you are directed to the new Magento Glossary site (`glossary.magento.com`)
