### PR TITLE
Add logic for creating JSON files

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -73,24 +73,23 @@ exports.createPages = ({ graphql, actions }) => {
     })
 
     // Create JSON data from markdown and frontmatter for external service consumption
-    result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-      let data = {
-        path: node.fields.slug,
-        tags: node.frontmatter.tags,
-        excerpt: node.excerpt,
-        title: node.frontmatter.title,
-        wordClasses: node.frontmatter.wordClasses,
-        synonyms: node.frontmatter.synonyms,
-        relatedTerms: node.frontmatter.relatedTerms,
+    fs.mkdir(path.join('public', 'data'), { recursive: true }, err => {
+      if (err) {
+        console.error(err)
+        return
       }
-      fs.mkdir('public'.concat(data.path), { recursive: true }, err => {
-        if(err){
-          console.error(err);
-          return;
+      result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+        let data = {
+          path: node.fields.slug,
+          tags: node.frontmatter.tags,
+          excerpt: node.excerpt,
+          title: node.frontmatter.title,
+          wordClasses: node.frontmatter.wordClasses,
+          synonyms: node.frontmatter.synonyms,
+          relatedTerms: node.frontmatter.relatedTerms,
         }
-
         fs.writeFile(
-          'public'.concat(data.path, 'index.json'),
+          path.join('public', 'data', path.basename(data.path) + '.json'),
           JSON.stringify(data),
           err => {
             if (err) {


### PR DESCRIPTION
## Purpose of this PR (required)

New feature that creates JSON files from markdown files that contain frontmatter and text excerpt data.

Fixes #13 

## Validation steps

1. Delete any existing `.cache` and `public` directories: `rm -fr .cache public`
2. Build the html: `yarn run build`
3. Verify existence of `public/data` folder
4. Verify existence of JSON files for each term in the public folder. e.g. `public/data/xml.json`
5. Verify file contains valid JSON data about the term