### PR TITLE
Fixes broken internal links/synonyms and other URLs. (magento-research)

### DIFF
--- a/src/terms/anchor-text.md
+++ b/src/terms/anchor-text.md
@@ -6,6 +6,6 @@
     - "programming"
   synonyms: []
   relatedTerms:
-    - "search engine optimization"
+    - "search-engine-optimization"
 ---
 The text, or label, in a hyperlink that is visible and clickable. Anchor text is important in search engine optimization.

--- a/src/terms/api.md
+++ b/src/terms/api.md
@@ -8,11 +8,11 @@
     - "application programming"
     - "interface"
     - "integration API"
-    - "web API"
+    - "web-api"
   relatedTerms:
-    - "web API"
-    - "integration API"
-    - "service contract"
+    - "web-api"
+    - "integration-api"
+    - "service-contract"
 ---
 Abbreviation for application program interface. A software interface that lets third-party applications read and write to a system using programming language constructs or statements. Magento supports and provides [REST](https://devdocs.magento.com/guides/v2.3/get-started/rest_front.html) and [SOAP](https://devdocs.magento.com/guides/v2.3/get-started/soap/soap-web-api-calls.html).
 

--- a/src/terms/area.md
+++ b/src/terms/area.md
@@ -6,8 +6,7 @@
     - "magento-software"
   synonyms: []
   relatedTerms:
-    - "DevDocs - Modules and Areas"
-    - "Magento component"
+    - "magento-component"
     - "storefront"
 ---
 Area is an abstract term for a Magento application scope. Areas are logical components that organize code for optimized request processing. Areas reduce the memory demands of configuration objects accessed from the storefront, and they streamline web service calls by loading only the required dependent code. Each area can contain completely different code to process URLs and requests.

--- a/src/terms/cache-type.md
+++ b/src/terms/cache-type.md
@@ -6,7 +6,6 @@
     - "programming"
   synonyms: []
   relatedTerms:
-    - "overview-of-cache-types"
-    - "manage-the-cache"
+    - "cache-types"
 ---
 A cache stores data so that future calls for that data can be loaded quicker, and Magento includes these types: configuration, layout, block HTML layout, full page (the most well-known), collections, DDL, EAV, reflection, translation, integration configuration, integration API configuration, web services configuration. Other types can be created and defined.

--- a/src/terms/cart-rules.md
+++ b/src/terms/cart-rules.md
@@ -8,7 +8,7 @@
     - "product"
   synonyms: []
   relatedTerms:
-    - "catalog rule"
-    - "shopping cart"
+    - "catalog-rules"
+    - "shopping-cart"
 ---
 Price rules which are applied to the shopping cart, and trigger an action in response to a set of conditions. Used to create promotions.

--- a/src/terms/catalog-rules.md
+++ b/src/terms/catalog-rules.md
@@ -8,7 +8,7 @@
     - "product"
   synonyms: []
   relatedTerms:
-    - "cart-rule"
+    - "cart-rules"
     - "catalog"
 ---
 Price rules which are applied to specific product(s), and trigger an action in response to a set of conditions. Used to create promotions.

--- a/src/terms/composer-package.md
+++ b/src/terms/composer-package.md
@@ -7,7 +7,6 @@
   synonyms: []
   relatedTerms:
     - "composer"
-    - "composer-website"
     - "package"
 ---
 A library, or file bundle, that is obtained using Composer — an external software — and that provides functionality or fulfills a dependency. The content of the package contains PHP code, a name and a version that identify the package, as well as metadata. For installation, the source definition is the information that is most relevant — this describes where to get the package contents and any dependencies.

--- a/src/terms/entity.md
+++ b/src/terms/entity.md
@@ -7,7 +7,7 @@
   synonyms: []
   relatedTerms:
     - "attribute"
-    - "cart rule"
-    - "catalog rule"
+    - "cart-rules"
+    - "catalog-rules"
 ---
 A unique unit or object in programming. Contains attributes or parameters that can be modified. Examples include staging — where an update can change entities such as price rules, products or categories — and database records — where service contracts include data structures that are sent and received.

--- a/src/terms/graphql.md
+++ b/src/terms/graphql.md
@@ -15,7 +15,7 @@
 ---
 [GraphQL](https://graphql.org/) is a data query language developed internally by Facebook in 2012 before being publicly released in 2015. Magento implements GraphQL to provide an alternative to REST and SOAP web APIs for frontend development.
 
-[PWA Studio](https://magento-research.github.io/pwa-studio/) uses GraphQL for development. GraphQL is a specification for a data query language on the client side and a service layer on the server side. It is often seen as an alternative to using REST endpoints.
+[PWA Studio](https://github.com/magento/pwa-studio) uses GraphQL for development. GraphQL is a specification for a data query language on the client side and a service layer on the server side. It is often seen as an alternative to using REST endpoints.
 
 One of the main advantages GraphQL has over REST is that a single GraphQL endpoint can accommodate requests for any combination of X, Y, and Z pieces of data, whereas REST requires specialized endpoints for different data request combinations. Unlike REST, which can require multiple server requests to aggregate data, a single GraphQL request returns only the data needed and nothing more.
 

--- a/src/terms/integration-api.md
+++ b/src/terms/integration-api.md
@@ -6,7 +6,7 @@
     - "programming"
   synonyms:
     - "API"
-    - "web API"
+    - "web-api"
   relatedTerms:
     - "api"
 ---

--- a/src/terms/layout-instructions.md
+++ b/src/terms/layout-instructions.md
@@ -9,7 +9,7 @@
   relatedTerms:
     - "layout"
     - "block"
-    - "containers"
-    - "ui-components"
+    - "container"
+    - "ui-component"
 ---
 Markup in a layout file that describes changes to be applied to a structured element tree of blocks, containers, and UI components. A single layout file can contain multiple layout instructions. Layout instructions are encoded in XML in layout files.

--- a/src/terms/layout-update.md
+++ b/src/terms/layout-update.md
@@ -6,7 +6,5 @@
     - "design"
     - "magento-software"
   synonyms: []
-  relatedTerms:
-    - "layout-update-examples"
 ---
 Used for snippets of code that that are added to modify the XML layout or to import the layout instructions from another file.

--- a/src/terms/magento.md
+++ b/src/terms/magento.md
@@ -10,7 +10,6 @@
     - "Magneto"
     - "magenta"
   relatedTerms:
-    - "magento-trademark-requirements"
     - "adobe"
 ---
 The company — "Magento" or "Magento, An Adobe Company" — includes several products in the following categories: digital commerce, order management, and other industry solutions. The Magento term is a registered trademark and a company name.

--- a/src/terms/metapackage.md
+++ b/src/terms/metapackage.md
@@ -6,7 +6,7 @@
     - "programming"
   synonyms: []
   relatedTerms:
-    - "composer-types"
+    - "composer"
     - "package"
 ---
 An empty package that contains requirements and will trigger their installation, but neither contains files nor writes anything to the filesystem. No dist or source key is required for installation.

--- a/src/terms/mixin.md
+++ b/src/terms/mixin.md
@@ -7,7 +7,6 @@
   synonyms: []
   relatedTerms:
     - "less"
-    - "magento-ui-library"
     - "ui-component"
 ---
 A class that contains a combination of methods from other classes. Mixins encourage code reuse and can be used to avoid the inheritance ambiguity that multiple inheritance can cause (the diamond problem), or to work around lack of support for multiple inheritance in a language.

--- a/src/terms/module.md
+++ b/src/terms/module.md
@@ -6,8 +6,6 @@
     - "magento-software"
   synonyms: []
   relatedTerms:
-    - "module-reference"
-    - "magento-module"
     - "php"
     - "xml"
     - "block"

--- a/src/terms/package.md
+++ b/src/terms/package.md
@@ -8,6 +8,6 @@
   relatedTerms:
     - "composer-package"
     - "language-package"
-    - "meta-package"
+    - "metapackage"
 ---
 The process of creating a distributable module for Magento Marketplace or another distribution system.

--- a/src/terms/platform-as-a-service.md
+++ b/src/terms/platform-as-a-service.md
@@ -7,7 +7,7 @@
   synonyms:
     - "PaaS"
   relatedTerms:
-    - "cloud services"
+    - "cloud-services"
     - "payments-as-a-service"
     - "software-as-a-service"
 ---

--- a/src/terms/pwa.md
+++ b/src/terms/pwa.md
@@ -16,12 +16,12 @@
 ---
 A Progressive Web App, or PWA, is a web application that uses modern web technologies and design patterns to provide a reliable, fast, and engaging user experience. PWA sites are fast, secure, responsive for all devices, cross-browser compatible, supports an offline mode, etc.
 
-The Magento PWA Studio project is a set of developer tools that allow for the development, deployment, and maintenance of a PWA storefront on top of Magento 2. It uses modern [tools and libraries](https://magento-research.github.io/pwa-studio/technologies/tools-libraries/) to create a build system and framework that adheres to the Magento principle of extensibility.
+The Magento PWA Studio project is a set of developer tools that allow for the development, deployment, and maintenance of a PWA storefront on top of Magento 2. It uses modern [tools and libraries](https://magento.github.io/pwa-studio/technologies/tools-libraries/) to create a build system and framework that adheres to the Magento principle of extensibility.
 
 PWA is also a Magento Community Engineering project, open to contributions:
 
-* [GitHub Repository](https://github.com/magento-research/pwa-studio)
+* [GitHub Repository](https://github.com/magento/pwa-studio)
 * [ZenHub](https://app.zenhub.com/workspace/o/magento-research/pwa-studio/boards?repos=137249745)
 * [#pwa Slack Channel](https://magentocommeng.slack.com/messages/C8076E0KS)
 
-Learn more: [Magento PWA Documentation](https://magento-research.github.io/pwa-studio/)
+Learn more: [Magento PWA Documentation](https://magento.github.io/pwa-studio/)

--- a/src/terms/react.md
+++ b/src/terms/react.md
@@ -11,4 +11,4 @@
   relatedTerms:
     - "pwa"
 ---
-[PWA Studio](https://magento-research.github.io/pwa-studio/)  uses [React](https://reactjs.org/) for development. React officially describes itself as a _JavaScript library for building user interfaces_. The library provides many features that make PWA development easier: builds UIs, declarative for describing the interface based on application states, and creates modular and reusable UI components.
+[PWA Studio](https://github.com/magento/pwa-studio)  uses [React](https://reactjs.org/) for development. React officially describes itself as a _JavaScript library for building user interfaces_. The library provides many features that make PWA development easier: builds UIs, declarative for describing the interface based on application states, and creates modular and reusable UI components.

--- a/src/terms/redux.md
+++ b/src/terms/redux.md
@@ -12,6 +12,6 @@
     - "pwa"
     - "react"
 ---
-[PWA Studio](https://magento-research.github.io/pwa-studio/) uses [Redux](https://redux.js.org/) for development. Redux is a JavaScript library used for managing state in a web application.
+[PWA Studio](https://github.com/magento/pwa-studio) uses [Redux](https://redux.js.org/) for development. Redux is a JavaScript library used for managing state in a web application.
 
 It provides a global store object that holds application state that multiple components depend on. Components that plug into the store have direct access to the specific state data they need. This library is often paired with React to alleviate the problem of passing data down multiple component layers.

--- a/src/terms/sales-rules.md
+++ b/src/terms/sales-rules.md
@@ -7,7 +7,7 @@
     - "product"
   synonyms: []
   relatedTerms:
-    - "cart-rule"
-    - "catalog-rule"
+    - "cart-rules"
+    - "catalog-rules"
 ---
 Includes cart and catalog rules, which used to price a product for promotions.

--- a/src/terms/service-worker.md
+++ b/src/terms/service-worker.md
@@ -13,4 +13,4 @@
 ---
 A service worker is a script that runs in the background. Progressive web applications use service workers for caching and resource retrieval.
 
-Learn more: [Magento PWA Documentation](https://magento-research.github.io/pwa-studio/), [Basic Concepts](https://magento-research.github.io/pwa-studio/technologies/basic-concepts/)
+Learn more: [Magento PWA Documentation](https://github.com/magento/pwa-studio), [Basic Concepts](https://magento.github.io/pwa-studio/technologies/basic-concepts/)

--- a/src/terms/shopping-cart.md
+++ b/src/terms/shopping-cart.md
@@ -11,6 +11,6 @@
     - "cart"
     - "basket"
   relatedTerms:
-    - "cart-rule"
+    - "cart-rules"
 ---
 The set of products that a customer has selected to purchase, but has not yet purchased. Also refers to an area of an ecommerce site where these products can be found in order to review and checkout.

--- a/src/terms/software-as-a-service.md
+++ b/src/terms/software-as-a-service.md
@@ -7,7 +7,7 @@
   synonyms:
     - "SaaS"
   relatedTerms:
-    - "cloud services"
+    - "cloud-services"
     - "payments-as-a-service"
     - "platform-as-a-service"
 ---

--- a/src/terms/upward.md
+++ b/src/terms/upward.md
@@ -12,7 +12,7 @@
   relatedTerms:
     - "pwa"
 ---
-[PWA Studio](https://magento-research.github.io/pwa-studio/) uses [UPWARD](https://magento-research.github.io/pwa-studio/technologies/upward/) in development. UPWARD is an acronym for Unified Progressive Web App Response Definition. An UPWARD definition file describes how a web server delivers and supports a Progressive Web Application.
+[PWA Studio](https://github.com/magento/pwa-studio) uses [UPWARD](https://magento.github.io/pwa-studio/technologies/upward/) in development. UPWARD is an acronym for Unified Progressive Web App Response Definition. An UPWARD definition file describes how a web server delivers and supports a Progressive Web Application.
 
 UPWARD definition files provide details about server behavior using platform-independent, declarative language. This lets a Progressive Web Application run on top of an UPWARD-compliant server in any language on any tech stack because the application is only concerned about the HTTP endpoint behavior from the UPWARD server.
 


### PR DESCRIPTION
## Scope of this PR

- Editorial: Typos, grammatical inconsistencies, or minor rewrites

## Purpose of this PR (required)

This PR fixes a number of internal 404s (missing dashes, etc) and old URLs found in a broken link report.